### PR TITLE
Use decimal.Decimal to parse strings

### DIFF
--- a/ligotimegps/__init__.py
+++ b/ligotimegps/__init__.py
@@ -19,6 +19,7 @@
 
 from math import (modf, log)
 from functools import wraps
+from decimal import Decimal
 
 try:
     from functools import total_ordering
@@ -86,17 +87,18 @@ class LIGOTimeGPS(object):
             nanoseconds += ns * 1e9
         elif not isinstance(seconds, six.integer_types):
             if isinstance(seconds, (six.binary_type, six.text_type)):
-                sign = -1 if seconds.lstrip().startswith("-") else +1
                 try:
-                    if "." in seconds:
-                        seconds, ns = seconds.split(".")
-                        ns = round(sign * float("." + ns) * 1e9)
-                    else:
-                        ns = 0
-                    seconds = int(seconds)
-                except:
+                    seconds = str(Decimal(seconds).canonical())
+                except ArithmeticError:
                     raise TypeError("invalid literal for LIGOTimeGPS(): %s"
                                     % seconds)
+                sign = -1 if seconds.lstrip().startswith("-") else +1
+                if "." in seconds:
+                    seconds, ns = seconds.split(".")
+                    ns = round(sign * float("." + ns) * 1e9)
+                else:
+                    ns = 0
+                seconds = int(seconds)
                 nanoseconds += ns
             elif (hasattr(seconds, "gpsSeconds") and
                   hasattr(seconds, "gpsNanoSeconds")):  # lal.LIGOTimeGPS

--- a/ligotimegps/__init__.py
+++ b/ligotimegps/__init__.py
@@ -88,14 +88,14 @@ class LIGOTimeGPS(object):
         elif not isinstance(seconds, six.integer_types):
             if isinstance(seconds, (six.binary_type, six.text_type)):
                 try:
-                    seconds = str(Decimal(seconds).canonical())
+                    seconds = str(Decimal(seconds))
                 except ArithmeticError:
                     raise TypeError("invalid literal for LIGOTimeGPS(): %s"
                                     % seconds)
-                sign = -1 if seconds.lstrip().startswith("-") else +1
+                sign = -1 if seconds.startswith("-") else +1
                 if "." in seconds:
                     seconds, ns = seconds.split(".")
-                    ns = round(sign * float("." + ns) * 1e9)
+                    ns = sign * int(ns.ljust(9, '0'))
                 else:
                     ns = 0
                 seconds = int(seconds)

--- a/ligotimegps/test_ligotimegps.py
+++ b/ligotimegps/test_ligotimegps.py
@@ -52,6 +52,9 @@ class LIGOTimeGPSTests(unittest.TestCase):
         a = LIGOTimeGPS("1", "234")
         self.assertEqual(a.gpsSeconds, 1)
         self.assertEqual(a.gpsNanoSeconds, 234)
+        a = LIGOTimeGPS("1.2345678987654321e9")
+        self.assertEqual(a.gpsSeconds, 1234567898)
+        self.assertEqual(a.gpsNanoSeconds, 765432100)
         # check errors
         self.assertRaises(TypeError, LIGOTimeGPS, 'test')
         self.assertRaises(TypeError, LIGOTimeGPS, None)


### PR DESCRIPTION
This PR updates the `LIGOTimeGPS` `str` value parser to use `decimal.Decimal`, which has logic to handle basically anything that looks like a number, e.g. `1.23456789e9` (which wasn't supported before).