### PR TITLE
Upgrade pip/setuptools before CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ python:
   - '3.5'
   - '3.6'
   - 'nightly'
+before_install:
+  - pip install --upgrade pip setuptools
 install:
   - pip install .
 before_script:


### PR DESCRIPTION
This PR attemps to fix [this build error](https://travis-ci.org/lscsoft/ligotimegps/jobs/343756104) by adding a step to upgrade `pip`/`setuptools` before building `ligotimegps`.