### PR TITLE
Restrict coveralls version for python-2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,13 @@ python:
 install:
   - pip install .
 before_script:
-  - pip install "pytest>=2.8" pytest-runner
+  - [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]] && pip install "coverage <= 4.5.1"
+  - pip install coverage "pytest>=2.8" pytest-runner
 script:
   - coverage run ./setup.py test
 after_success:
-  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then
-      pip install "coveralls < 1.3.0"
-    else
-      pip install "coveralls"
-    fi
+  - [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]] && pip install "coveralls < 1.3.0"
+  - pip install "coveralls"
   - coveralls
 cache: pip
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ python:
 install:
   - pip install .
 before_script:
-  - [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]] && pip install "coverage <= 4.5.1"
+  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "coverage <= 4.5.1"; fi
   - pip install coverage "pytest>=2.8" pytest-runner
 script:
   - coverage run ./setup.py test
 after_success:
-  - [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]] && pip install "coveralls < 1.3.0"
+  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "coveralls < 1.3.0"; fi
   - pip install "coveralls"
   - coveralls
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ deploy:
     password:
       secure: yTbJ/U2oQxtrOmmrTlHg7aU0jJtFbJwHfU6wd3+zKcddNF4U4HQATji6BeP5WwnijRvGvq/d+341NSDUpa0tMYLIS6PUPAZHJeueL8GiVl+UAeA4IT9LF6qi1tRQHGXTTuvg1N7gyJM2b2IhhZB1Rjevjr5HzRPBC/yVzk0pmpij96KRiMmmY68NGskGBiMU7yPjwm1dExXhNrWnzQRdSKzNEX0dl9JQrKqz/VBYrfT9zFsdKRpYGbScssgd/omZ6UAMowi4pWqBPxxl1aVMSRyCn9soL13J+sc3TH9CqOD5glu6KWBGSJdvQ4mWdflqq5f9l1ARvUDv4cuJ3HE/89NssMtrORZgcMdyTos9mN+6BQg8se+nfWIxcHZuQPpG9y+wSx/HyZdzrgY3DuOyh3c8BP1fbAaC1FS+9cLO8PN+qA8I7JbQjd5q2vRbNeZs9qeN0i5NE22tR/nUVeqgbn53GdnImwO/kmpRHvsyrOZsPWCiDko/aDMO99iWNzOflMJVgtlBZUn0Iiq6k4HNZwZ2/bymLwFbjdSxqUjsYQEwKqgfq0OmZlsT9U9qRyOZnqBQl8a+AfAaTFE7fNFZ573YqA44D/4StT6/KTOvliL7g6PvX77VQrguatkCsySviuOtQZ+FWqhTf9VsFWcDUFiBQ6fCV/G+of6ZSflRlzM=
     skip_upload_docs: true
+    distributions: sdist bdist_wheel
     on:
       branch: master
       tags: true
-      distributions: sdist bdist_wheel
       repo: lscsoft/ligotimegps

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,15 @@ python:
 install:
   - pip install .
 before_script:
-  - pip install coveralls "pytest>=2.8" pytest-runner
+  - pip install "pytest>=2.8" pytest-runner
 script:
   - coverage run ./setup.py test
 after_success:
+  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then
+      pip install "coveralls < 1.3.0"
+    else
+      pip install "coveralls"
+    fi
   - coveralls
 cache: pip
 deploy:


### PR DESCRIPTION
This PR adds a version check to install the appropriate last-compatible release of coveralls for python2.6.