### PR TITLE
Improved TypeError messages in LIGOTimeGPS

### DIFF
--- a/ligotimegps/__init__.py
+++ b/ligotimegps/__init__.py
@@ -84,8 +84,8 @@ class LIGOTimeGPS(object):
                 try:
                     seconds = str(Decimal(seconds))
                 except ArithmeticError:
-                    raise TypeError("invalid literal for LIGOTimeGPS(): %s"
-                                    % seconds)
+                    raise TypeError("invalid literal for {0}: {1}".format(
+                       type(self).__name__, seconds))
                 sign = -1 if seconds.startswith("-") else +1
                 if "." in seconds:
                     seconds, ns = seconds.split(".")
@@ -99,7 +99,8 @@ class LIGOTimeGPS(object):
                 nanoseconds += seconds.gpsNanoSeconds
                 seconds = seconds.gpsSeconds
             else:
-                raise TypeError(seconds)
+                raise TypeError("cannot convert {0!r} ({0.__class__.__name__})"
+                                " to {1.__name__}".format(seconds, type(self)))
         self._seconds = seconds + int(nanoseconds // 1000000000)
         self._nanoseconds = int(nanoseconds % 1000000000)
 

--- a/ligotimegps/test_ligotimegps.py
+++ b/ligotimegps/test_ligotimegps.py
@@ -62,11 +62,15 @@ def test_creation():
     assert a.gpsSeconds == 1234567898
     assert a.gpsNanoSeconds == 765432100
 
-    # check errors
-    with pytest.raises(TypeError):
-        LIGOTimeGPS('test')
-    with pytest.raises(TypeError):
-        LIGOTimeGPS(None)
+
+@pytest.mark.parametrize('input_, errstr', [
+    ('test', 'invalid literal for LIGOTimeGPS: test'),
+    (None, 'cannot convert None (NoneType) to LIGOTimeGPS'),
+])
+def test_creation_errors(input_, errstr):
+    with pytest.raises(TypeError) as err:
+        LIGOTimeGPS(input_)
+    assert str(err.value) == errstr
 
 
 def test_str():


### PR DESCRIPTION
This PR improves the error reporting from `LIGOTimeGPS.__init__`.